### PR TITLE
Added several parameters to #save_screenshot method.

### DIFF
--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -242,16 +242,16 @@ module Capybara::Cuprite
     end
 
     def render(path, _options = {})
-      # check_render_options!(options)
-      # options[:full] = !!options[:full]
-      data = Base64.decode64(render_base64)
-      File.open(path.to_s, "w") { |f| f.write(data) }
+      format = _options[:format] || 'png'
+      base64 = render_base64(format, _options)
+      data = Base64.decode64(base64)
+      File.open(path, "w") { |file| file.write(data) }
     end
 
-    def render_base64(format = "png", _options = {})
-      # check_render_options!(options)
-      # options[:full] = !!options[:full]
-      page.command("Page.captureScreenshot", format: format)["data"]
+    def render_base64(format = 'png', _options = {})
+      raise "Unsupported screenshot format" unless %w(jpeg png).include?(format.to_s)
+      render_options = filter_render_options(_options)
+      page.command("Page.captureScreenshot", render_options)["data"]
     end
 
     def set_zoom_factor(zoom_factor)
@@ -383,10 +383,8 @@ module Capybara::Cuprite
 
     private
 
-    def check_render_options!(options)
-      return if !options[:full] || !options.key?(:selector)
-      warn "Ignoring :selector in #render since :full => true was given at #{caller(1..1).first}"
-      options.delete(:selector)
+    def filter_render_options(options = {})
+      options.slice *%i(format quality clip fromSurface)
     end
 
     def find_all(method, selector, within = nil)

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -226,6 +226,29 @@ module Capybara::Cuprite
       end
     end
 
+    describe "#save_screenshot parameters" do
+      let(:format) { :png }
+      let(:file_path) { CUPRITE_ROOT + "/spec/tmp/screenshot.#{format}" }
+
+      before(:each) { FileUtils.rm_f file_path }
+
+      it 'save screenshot with default parameters' do
+        @session.visit("/")
+
+        screenshot_path = @driver.save_screenshot(file_path)
+
+        expect(File).to exist(file_path)
+      end
+
+      it 'raising unsupported format error' do
+        @session.visit("/")
+
+        expect {
+          @driver.save_screenshot(file_path, format: 'gif')
+        }.to raise_error("Unsupported screenshot format")
+      end
+    end
+
     describe "#save_screenshot", skip: true do
       let(:format) { :png }
       let(:file) { CUPRITE_ROOT + "/spec/tmp/screenshot.#{format}" }


### PR DESCRIPTION
Hi, @machinio! I found your issue searching by #hacktoberfest tag.

I know your company and I want to contribute in your projects and in particular by doing work on this issue.

Here I've done #11 issue requirements and now all [supported optional parameters](https://chromedevtools.github.io/devtools-protocol/tot/Page#method-captureScreenshot) are supported by #save_screenshot and #render_base64 methods.

Probably you have some corrections to my code – I glad to hear and to fix that. :)

Also I see that you have some part of skipped tests that touches screenshot feature (driver_spec.rb).

Can I fix it here? Otherwise we can open new issue and to fix tests there :)