### PR TITLE
Made it possible to autodetect the browser path on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 addons:
   chrome: stable
-env:
-  - BROWSER_PATH=/usr/bin/google-chrome
 gemfile:
   - gemfiles/capybara2.gemfile
   - gemfiles/capybara3.gemfile

--- a/lib/capybara/cuprite/browser/process.rb
+++ b/lib/capybara/cuprite/browser/process.rb
@@ -106,7 +106,7 @@ module Capybara::Cuprite
           @path = exe if File.exist?(exe)
         else
           exe ||= "chrome"
-          @path = Cliver.detect(exe)
+          @path = Cliver.detect(exe) || Cliver.detect("google-chrome")
         end
 
         unless @path

--- a/lib/capybara/cuprite/browser/process.rb
+++ b/lib/capybara/cuprite/browser/process.rb
@@ -7,7 +7,7 @@ module Capybara::Cuprite
     class Process
       KILL_TIMEOUT = 2
 
-      BROWSER_PATH = ENV.fetch("BROWSER_PATH", "chrome")
+      BROWSER_PATH = ENV["BROWSER_PATH"]
       BROWSER_HOST = "127.0.0.1"
       BROWSER_PORT = "0"
 
@@ -101,7 +101,13 @@ module Capybara::Cuprite
 
       def detect_browser_path
         exe = @options[:path] || BROWSER_PATH
-        @path = Cliver.detect(exe)
+        if RUBY_PLATFORM.include?('darwin')
+          exe ||= "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+          @path = exe if File.exist?(exe)
+        else
+          exe ||= "chrome"
+          @path = Cliver.detect(exe)
+        end
 
         unless @path
           message = "Could not find an executable `#{exe}`. Try to make it " \

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,8 @@ require "capybara/cuprite"
 require "support/test_app"
 
 Capybara.register_driver(:cuprite) do |app|
-  options = Hash.new
-  options.merge!(path: ENV["BROWSER_PATH"]) if ENV["BROWSER_PATH"]
-  driver = Capybara::Cuprite::Driver.new(app, options)
-  puts `#{driver.browser.process.path} -version`
+  driver = Capybara::Cuprite::Driver.new(app, {})
+  puts `#{driver.browser.process.path.gsub(" ", "\\ ")} -version`
   driver
 end
 


### PR DESCRIPTION
This should fix #23 - although it'd be good if someone else using a mac could try this branch and confirm.

On mac it now defaults to using Google Chrome in the Applications folder, if you do not specify `BROWSER_PATH`. I've not used [Cliver](https://github.com/yaauie/cliver) for this, as it doesn't work well on mac (you still have to specify the whole path if your executable is inside /Applications, because Cliver only checks your `PATH`).

As a bonus I've also made it such that on linux, it can detect both `chrome` and `google-chrome` executables (some platforms use one name, some use the other)