### PR TITLE
Added support for websocket-driver 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ env:
   - BROWSER_PATH=/usr/bin/google-chrome
 gemfile:
   - gemfiles/capybara2.gemfile
-  - gemfiles/capybara3.gemfile
+  - gemfiles/websocketdriver6.gemfile
+  - gemfiles/latest.gemfile
 language: ruby
 rvm:
   - 2.3

--- a/cuprite.gemspec
+++ b/cuprite.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency "capybara",         ">= 2.1", "< 4"
-  s.add_runtime_dependency "websocket-driver", "~> 0.7"
+  s.add_runtime_dependency "websocket-driver", ">= 0.6", "< 0.8"
   s.add_runtime_dependency "cliver",           "~> 0.3"
 
   s.add_development_dependency "image_size", "~> 2.0"

--- a/gemfiles/latest.gemfile
+++ b/gemfiles/latest.gemfile
@@ -2,6 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "capybara", "~> 3.0"
-
 gemspec path: "../"

--- a/gemfiles/websocketdriver6.gemfile
+++ b/gemfiles/websocketdriver6.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "websocket-driver", "~> 0.6"
+
+gemspec path: "../"


### PR DESCRIPTION
ActionCable (from Ruby on Rails) depends on websocket-driver ~> 0.6, but
currently cuprite depends on websocket-driver ~> 0.7, which means that
curprite can't be used on rails projects using actioncable.

I've changed the version of websocket specified in the gemspec to
allow 0.6, and added an extra travis build to check that it works
correctly.