### PR TITLE
Don't report arrays of nodes as a cyclic element

### DIFF
--- a/lib/capybara/cuprite/browser/javascripts/index.js
+++ b/lib/capybara/cuprite/browser/javascripts/index.js
@@ -24,7 +24,7 @@ class Cuprite {
           results.push(xpath.snapshotItem(i));
         }
       } else {
-        results = within.querySelectorAll(selector);
+        results = Array.from(within.querySelectorAll(selector));
       }
 
       return results;
@@ -441,6 +441,7 @@ class Cuprite {
   }
 
   isCyclic(object) {
+    if Array.isArray(object) && object.every(n => n instanceof Node) return false
     try {
       this._json.stringify(object);
       return false;

--- a/lib/capybara/cuprite/browser/runtime.rb
+++ b/lib/capybara/cuprite/browser/runtime.rb
@@ -125,8 +125,7 @@ module Capybara::Cuprite
             node = command("DOM.describeNode", nodeId: node_id)["node"].merge("nodeId" => node_id)
             { "target_id" => target_id, "node" => node }
           when "array"
-            check_cyclic = response["className"] != "NodeList"
-            reduce_props(object_id, [], check_cyclic) do |memo, key, value|
+            reduce_props(object_id, []) do |memo, key, value|
               next(memo) unless (Integer(key) rescue nil)
               value = value["objectId"] ? handle(value) : value["value"]
               memo.insert(key.to_i, value)
@@ -144,8 +143,8 @@ module Capybara::Cuprite
         end
       end
 
-      def reduce_props(object_id, to, check_cyclic = true)
-        if check_cyclic && cyclic?(object_id).dig("result", "value")
+      def reduce_props(object_id, to)
+        if cyclic?(object_id).dig("result", "value")
           return "(cyclic structure)"
         else
           props = command("Runtime.getProperties", objectId: object_id)


### PR DESCRIPTION
This has two parts:

1. Always return an Array of Nodes from find()
2. Exit early from isCyclic() if given an Array of Nodes

This should fix https://github.com/machinio/cuprite/issues/37