### PR TITLE
Fix spec_helper version check for Windows

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require "support/test_app"
 Capybara.register_driver(:cuprite) do |app|
   driver = Capybara::Cuprite::Driver.new(app, {})
   puts driver.browser.process.cmd.join(" ")
-  puts `#{driver.browser.process.path.gsub(" ", "\\ ")} -version`
+  puts `"#{driver.browser.process.path}" -version --headless --no-gpu`
   driver
 end
 


### PR DESCRIPTION
On Windows, there are two issues preventing `spec/spec_helper.rb` from running correctly:
- the `--version` of Chrome on Windows actually starts a new window, which is preventing the rest of the spec from running as this is a blocking process. So this adds the `--headless -no-gpu` options to the call so that they can run without blocking the test.
- Chrome default installation path is in `C:/Program Files (x86)/Google/Chrome` which means that parenthesis must be taken into account, so this simply quote the path so that it runs smoothly without too much care for spaces or special characters. This has been tested on both Mac and Windows