### PR TITLE
Fix Chrome path for Ubuntu

### DIFF
--- a/lib/capybara/cuprite/browser/process.rb
+++ b/lib/capybara/cuprite/browser/process.rb
@@ -138,7 +138,7 @@ module Capybara::Cuprite
           )
 
         unless @path
-          message = "Could not find an executable `#{exe}`. Try to make it " \
+          message = "Could not find an executable for chrome. Try to make it " \
                     "available on the PATH or set environment varible for " \
                     "example BROWSER_PATH=\"/Applications/Chromium.app/Contents/MacOS/Chromium\""
           raise Cliver::Dependency::NotFound.new(message)

--- a/lib/capybara/cuprite/browser/process.rb
+++ b/lib/capybara/cuprite/browser/process.rb
@@ -130,7 +130,7 @@ module Capybara::Cuprite
                 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
               ].find { |path| File.exist?(path) }
             else
-              %w[chromium google-chrome-unstable google-chrome-beta google-chrome chrome].reduce(nil) do |path, exe|
+              %w[chromium chromium-browser google-chrome-unstable google-chrome-beta google-chrome chrome].reduce(nil) do |path, exe|
                 path = Cliver.detect(exe)
                 break path if path
               end

--- a/lib/capybara/cuprite/browser/process.rb
+++ b/lib/capybara/cuprite/browser/process.rb
@@ -130,7 +130,7 @@ module Capybara::Cuprite
                 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
               ].find { |path| File.exist?(path) }
             else
-              %w[chromium chromium-browser google-chrome-unstable google-chrome-beta google-chrome chrome].reduce(nil) do |path, exe|
+              %w[chromium google-chrome-unstable google-chrome-beta google-chrome chrome chromium-browser].reduce(nil) do |path, exe|
                 path = Cliver.detect(exe)
                 break path if path
               end


### PR DESCRIPTION
Ubuntu uses `chromium-browser` as the default executable name.  This adds it as a valid option for the cliver search.

Also includes a fix to the error handling code for when cliver fails to locate the binary, which causes a runtime error rather than a helpful error message.