### PR TITLE
Make process startup timeout configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ end
 * `:host` (String) - Remote debugging address for headless Chrome
 * `:url_blacklist` (Array) - array of strings to match against requested URLs
 * `:url_whitelist` (Array) - array of strings to match against requested URLs
+* `:process_timeout` (Integer) - How long to wait for the Chrome process to respond on startup
 
 
 ### URL Blacklisting & Whitelisting ###


### PR DESCRIPTION
Browser sometimes takes a little longer to startup on busy ci systems. PR makes the existing startup timeout configurable via the driver options. 