### PR TITLE
fix #set to respect calls to preventDefault()

### DIFF
--- a/lib/capybara/cuprite/browser/javascripts/index.js
+++ b/lib/capybara/cuprite/browser/javascripts/index.js
@@ -123,13 +123,17 @@ class Cuprite {
       value = value.substr(0, node.maxLength);
     }
 
+    let valueBefore = node.value;
+
     this.trigger(node, "focus");
     this.setValue(node, "");
 
     if (node.type == "number" || node.type == "date") {
       this.setValue(node, value);
+      this.input(node);
     } else if (node.type == "time") {
       this.setValue(node, new Date(value).toTimeString().split(" ")[0]);
+      this.input(node);
     } else if (node.type == "datetime-local") {
       value = new Date(value);
       let year = value.getFullYear();
@@ -139,20 +143,29 @@ class Cuprite {
       let min = ("0" + value.getMinutes()).slice(-2);
       let sec = ("0" + value.getSeconds()).slice(-2);
       this.setValue(node, `${year}-${month}-${date}T${hour}:${min}:${sec}`);
+      this.input(node);
     } else {
       for (let i = 0; i < value.length; i++) {
         let char = value[i];
         let keyCode = this.characterToKeyCode(char);
-        this.keyupdowned(node, "keydown", keyCode);
-        this.setValue(node, node.value + char);
+        // call the following functions in order, if one returns false (preventDefault),
+        // stop the call chain
+        [
+          () => this.keyupdowned(node, "keydown", keyCode),
+          () => this.keypressed(node, false, false, false, false, char.charCodeAt(0), char.charCodeAt(0)),
+          () => {
+            this.setValue(node, node.value + char)
+            this.input(node)
+          }
+        ].some(fn => fn())
 
-        this.keypressed(node, false, false, false, false, char.charCodeAt(0), char.charCodeAt(0));
         this.keyupdowned(node, "keyup", keyCode);
       }
     }
 
-    this.changed(node);
-    this.input(node);
+    if (valueBefore !== node.value) {
+      this.changed(node);
+    }
     this.trigger(node, "blur");
   }
 
@@ -172,14 +185,20 @@ class Cuprite {
     node.dispatchEvent(event);
   }
 
+  /**
+   * @return {boolean} false when an event handler called preventDefault()
+   */
   keyupdowned(node, eventName, keyCode) {
     let event = document.createEvent("UIEvents");
     event.initEvent(eventName, true, true);
     event.keyCode  = keyCode;
     event.charCode = 0;
-    node.dispatchEvent(event);
+    return !node.dispatchEvent(event);
   }
 
+  /**
+   * @return {boolean} false when an event handler called preventDefault()
+   */
   keypressed(node, altKey, ctrlKey, shiftKey, metaKey, keyCode, charCode) {
     event = document.createEvent("UIEvents");
     event.initEvent("keypress", true, true);
@@ -190,7 +209,7 @@ class Cuprite {
     event.metaKey  = metaKey;
     event.keyCode  = keyCode;
     event.charCode = charCode;
-    node.dispatchEvent(event);
+    return !node.dispatchEvent(event);
   }
 
   characterToKeyCode(char) {

--- a/spec/support/views/input_events.erb
+++ b/spec/support/views/input_events.erb
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <body>
+    <input id="input" type="text">
+    <div id="output"></div>
+
+    <script>
+      window.input = document.querySelector('#input')
+      window.output = document.querySelector('#output')
+      const log = (s) => output.textContent = `${output.textContent} ${s}`
+      input.addEventListener('keydown', () => log('keydown'))
+      input.addEventListener('keypress', () => log('keypress'))
+      input.addEventListener('input', () => log('input'))
+      input.addEventListener('keyup', () => log('keyup'))
+      input.addEventListener('change', () => log('change'))
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Hi,

while evaluating cuprite for our test suite, I observed duplicate entry in some of our currency inputs.
calling `fill_in("my dollar amount", 123)` would lead to an input value of `123123`.

I turns out that cuprite `#set` simulates the correct keyboard input lifecycle events, but does not respect any calls made to [Event.preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) within event handlers.

The reason we had double entry is that a third party input money masking library we use is capturing user input, `preventDefault`ing it, then setting it manually when it sees fit. 

this fixes a few things:
* if `keydown` is defaultPrevented, don't trigger `input` or `keypressed` events and don't change the input's value 
* if `keypress` is defaultPrevented, don't trigger `input` event and don't change the input's value 
* if the input's value was not altered after call to `#set`, don't trigger `change` event.
* triggers `input` event for each character instead of once for all characters at the end.
* triggers `change` event after `input` event, was reversed before

I used the various w3c docs to determine the behavior. To the best of my understanding, this behavior aligns cuprite with web standards

Happy to alter this code in any way you may prefer.
Feel free to use any of this to write your own patch.