### PR TITLE
 Allow browser url to be specified in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ end
 * `:url_blacklist` (Array) - array of strings to match against requested URLs
 * `:url_whitelist` (Array) - array of strings to match against requested URLs
 * `:process_timeout` (Integer) - How long to wait for the Chrome process to respond on startup
+* `:url` (String) - URL for a running instance of Chrome. If this is set, a browser process will not be spawned.
 
 
 ### URL Blacklisting & Whitelisting ###

--- a/lib/capybara/cuprite/browser.rb
+++ b/lib/capybara/cuprite/browser.rb
@@ -9,8 +9,6 @@ require "capybara/cuprite/browser/page"
 
 module Capybara::Cuprite
   class Browser
-    HOST = "127.0.0.1"
-    PORT = "0"
     TIMEOUT = 5
     WINDOW_SIZE = [1024, 768].freeze
     EXTENSIONS = [
@@ -19,7 +17,7 @@ module Capybara::Cuprite
 
     extend Forwardable
 
-    attr_reader :headers, :window_size, :host, :psot
+    attr_reader :headers, :window_size
 
     def self.start(*args)
       new(*args)
@@ -39,7 +37,7 @@ module Capybara::Cuprite
                 proxy_authorize) => :page
 
     attr_reader :process, :logger, :js_errors, :slowmo,
-                :url_blacklist, :url_whitelist, :url, :host, :port
+                :url_blacklist, :url_whitelist, :url
     attr_writer :timeout
 
     def initialize(options = nil)
@@ -47,11 +45,6 @@ module Capybara::Cuprite
       options ||= {}
 
       @url = options.key?(:url) ? Addressable::URI.parse(options[:url]) : nil
-      @port = @url ? @url.port : options.fetch(:port, PORT)
-      @host = @url ? @url.host : options.fetch(:host, HOST)
-
-      options[:port] ||= @port
-      options[:host] ||= @host
 
       @window_size = options.fetch(:window_size, WINDOW_SIZE)
       @original_window_size = @window_size

--- a/lib/capybara/cuprite/browser/page.rb
+++ b/lib/capybara/cuprite/browser/page.rb
@@ -57,8 +57,8 @@ module Capybara::Cuprite
           end
         end
 
-        host = @browser.process.host
-        port = @browser.process.port
+        host = @browser.ws_url.host
+        port = @browser.ws_url.port
         ws_url = "ws://#{host}:#{port}/devtools/page/#{@target_id}"
         @client = Client.new(browser, ws_url)
 

--- a/lib/capybara/cuprite/browser/process.rb
+++ b/lib/capybara/cuprite/browser/process.rb
@@ -5,6 +5,8 @@ require "cliver"
 module Capybara::Cuprite
   class Browser
     class Process
+      HOST = "127.0.0.1"
+      PORT = "0"
       KILL_TIMEOUT = 2
       PROCESS_TIMEOUT = 1
       BROWSER_PATH = ENV["BROWSER_PATH"]
@@ -80,10 +82,10 @@ module Capybara::Cuprite
         # Doesn't work on MacOS, so we need to set it by CDP as well
         @options.merge!("window-size" => options[:window_size].join(","))
 
-        port = options.fetch(:port)
+        port = options.fetch(:port, PORT)
         @options.merge!("remote-debugging-port" => port)
 
-        host = options.fetch(:host)
+        host = options.fetch(:host, HOST)
         @options.merge!("remote-debugging-address" => host)
 
         @options.merge!("user-data-dir" => Dir.mktmpdir)

--- a/lib/capybara/cuprite/driver.rb
+++ b/lib/capybara/cuprite/driver.rb
@@ -254,7 +254,9 @@ module Capybara::Cuprite
 
     def debug
       if @options[:inspector]
-        Process.spawn(browser.process.path, "http://#{browser.process.host}:#{browser.process.port}")
+        url = browser.ws_url
+        # TODO: fixme
+        Process.spawn(url.path, "http://#{url.host}:#{url.port}")
         pause
       else
         raise Error, "To use the remote debugging, you have to launch " \

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -7,6 +7,8 @@ require "chunky_png"
 
 module Capybara::Cuprite
   describe Driver do
+    include Spec::Support::ExternalBrowser
+
     around do |example|
       begin
         @session = TestSessions::Cuprite
@@ -923,6 +925,18 @@ module Capybara::Cuprite
     end
 
     it "allows the driver to have a custom host" do
+      with_external_browser do |url|
+        begin
+          driver = Capybara::Cuprite::Driver.new(@driver.app, url: url)
+          driver.visit session_url("/")
+          expect(driver.html).to include("Hello world!")
+        ensure
+          driver&.quit
+        end
+      end
+    end
+
+    it "allows for a custom browser url to be specified which" do
       begin
         # Use custom host "pointing" to localhost, specified by BROWSER_TEST_HOST env var.
         # Use /etc/hosts or iptables for this: https://superuser.com/questions/516208/how-to-change-ip-address-to-point-to-localhost

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "capybara/spec/spec_helper"
 require "capybara/cuprite"
 
 require "support/test_app"
+require "support/external_browser"
 
 Capybara.register_driver(:cuprite) do |app|
   options = {}

--- a/spec/support/external_browser.rb
+++ b/spec/support/external_browser.rb
@@ -17,23 +17,15 @@ module Spec
       end
 
       def with_external_browser
-        pid = nil
-        tmp = nil
+        url = URI.parse("http://127.0.0.1:32001")
+        opts = { host: url.host, port: url.port, window_size: [1400, 1400], headless: true }
+        process = Capybara::Cuprite::Browser::Process.new(opts)
 
         begin
-
-          tmp = Dir.mktmpdir
-          remote_debugging_port = 32222
-          args = "--user-data-dir=#{tmp} --remote-debugging-port=#{remote_debugging_port}"
-          exe = Capybara::Cuprite::Browser::Process.detect_browser_path
-          pid = Process.spawn("#{exe} #{args}", out: File::NULL)
-          wait_for_connection('localhost', remote_debugging_port)
-
-          url = "http://localhost:#{remote_debugging_port}"
-          yield url
+          process.start
+          yield url.to_s
         ensure
-          Process.kill('SIGTERM', pid)
-          FileUtils.rm_f tmp
+          process.stop
         end
       end
     end

--- a/spec/support/external_browser.rb
+++ b/spec/support/external_browser.rb
@@ -1,0 +1,41 @@
+module Spec
+  module Support
+    module ExternalBrowser
+      def wait_for_connection(host, port)
+        tries = 0
+
+        loop do
+          begin
+            Socket.tcp(host, port, connect_timeout: 3) {}
+            break
+          rescue Errno::ECONNREFUSED
+            raise if tries >= 50
+            tries += 1
+            sleep 0.1
+          end
+        end
+      end
+
+      def with_external_browser
+        pid = nil
+        tmp = nil
+
+        begin
+
+          tmp = Dir.mktmpdir
+          remote_debugging_port = 32222
+          args = "--user-data-dir=#{tmp} --remote-debugging-port=#{remote_debugging_port}"
+          exe = Capybara::Cuprite::Browser::Process.detect_browser_path
+          pid = Process.spawn("#{exe} #{args}", out: File::NULL)
+          wait_for_connection('localhost', remote_debugging_port)
+
+          url = "http://localhost:#{remote_debugging_port}"
+          yield url
+        ensure
+          Process.kill('SIGTERM', pid)
+          FileUtils.rm_f tmp
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows the ability to run Chrome from an external process that is not managed by Cuprite. This is particularly useful for parallel testing, and solves all of the problems listed in https://github.com/machinio/cuprite/issues/70. I have tried this on our test suite and it works very well. Would love any feedback :smile: 