### PR TITLE
Safely evaluate parents and path for orphan nodes.

### DIFF
--- a/lib/capybara/cuprite/browser/javascripts/index.js
+++ b/lib/capybara/cuprite/browser/javascripts/index.js
@@ -41,7 +41,7 @@ class Cuprite {
   parents(node) {
     let nodes = [];
     let parent = node.parentNode;
-    while (parent != document) {
+    while (parent && parent !== document) {
       nodes.push(parent);
       parent = parent.parentNode;
     }
@@ -95,12 +95,7 @@ class Cuprite {
   }
 
   path(node) {
-    let nodes = [node];
-    let parent = node.parentNode;
-    while (parent !== document) {
-      nodes.unshift(parent);
-      parent = parent.parentNode;
-    }
+    let nodes = [node].concat(this.parents(node));
 
     let selectors = nodes.map(node => {
       let prevSiblings = [];


### PR DESCRIPTION
It's possible for Cuprite to evaluate the parents or the path for a node
that no longer belongs to the document.