### PR TITLE
Fix deadlock on `Page.frameScheduledNavigation`

### DIFF
--- a/lib/capybara/cuprite/browser/frame.rb
+++ b/lib/capybara/cuprite/browser/frame.rb
@@ -62,7 +62,7 @@ module Capybara::Cuprite
           @mutex.try_lock
         end
 
-        @client.subscribe("Page.frameStoppedLoading") do |params|
+        handle_frame_end = proc do |params|
           # `DOM.performSearch` doesn't work without getting #document node first.
           # It returns node with nodeId 1 and nodeType 9 from which descend the
           # tree and we save it in a variable because if we call that again root
@@ -78,6 +78,9 @@ module Capybara::Cuprite
             signal if @waiting_frames.empty?
           end
         end
+
+        @client.subscribe("Page.frameStoppedLoading", &handle_frame_end)
+        @client.subscribe("Page.frameClearedScheduledNavigation", &handle_frame_end)
 
         @client.subscribe("Runtime.executionContextCreated") do |params|
           frame_id = params.dig("context", "auxData", "frameId")


### PR DESCRIPTION
When a `Page.frameScheduledNavigation` is received the mutex is locked
but never released. According to my logs Chrome sends a
`Page.frameClearedScheduledNavigation` to notify the end of this
process.

The setup code in `Page.frameScheduledNavigation` is similar to the one
when `Page.frameStartedLoading` is received, so I applied the same cleanup
code for both ending events `Page.frameStoppedLoading` and
`Page.frameClearedScheduledNavigation`.

---

I don't know if the same cleanup code should be applied in this case. But it fixes my problem.

This problem happens on a specific site only, and with Chrome 76 (I believe it doesn't happen with Chrome 74). The lock happens after the page is loaded, when there's no interaction. My code loads some pages and interact with them, and then calls the `#cookies` method twice for some reasons. The deadlock happens at that 2nd call.

The website is private so I can't provide access to it, but I can possibly provide some cuprite logs if needed.