### PR TITLE
Remove deprecated event `frameScheduledNavigation`

### DIFF
--- a/lib/capybara/cuprite/browser/frame.rb
+++ b/lib/capybara/cuprite/browser/frame.rb
@@ -56,12 +56,6 @@ module Capybara::Cuprite
           end
         end
 
-        @client.subscribe("Page.frameScheduledNavigation") do |params|
-          # Trying to lock mutex if frame is the main frame
-          @waiting_frames << params["frameId"]
-          @mutex.try_lock
-        end
-
         @client.subscribe("Page.frameStoppedLoading") do |params|
           # `DOM.performSearch` doesn't work without getting #document node first.
           # It returns node with nodeId 1 and nodeType 9 from which descend the


### PR DESCRIPTION
This is a new proposal to fix the deadlock mentioned in #88. In addition to the problem with Chrome 73 mentioned in the PR I also had failures on other websites.

It appears the `frameStartedLoading` and `frameScheduledNavigation` events can overlap and the code doesn't handle that well.

This change completely removes the handling of the `Page.frameScheduledNavigation` event, which [is deprecated](https://chromedevtools.github.io/devtools-protocol/tot/Page#event-frameScheduledNavigation).

It seems to work well on my use cases. Do you think this change is appropriate?